### PR TITLE
install conda vendor from the 309thEDDGE repo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,15 +4,15 @@ channels:
   - default
 dependencies:
   - click
-  - conda-vendor>=1.0.3
   - jinja2
   - pip
   - pre-commit
   - pytest
   - pytest-cov
-  - python
+  - python=3.11
   - requests
   - ruamel.yaml
   - urllib3
   - pip:
-    - -e .
+    - git+https://github.com/309thEDDGE/conda-vendor.git
+    - .


### PR DESCRIPTION
Resolves #

Changes proposed in this pull request:
adjust the environment.yml file to install conda vendor from the 309th github repo instead of from conda forge
